### PR TITLE
Support properties loading for alternate language codes (iw, in, ji) in Java < 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [8, 11]
+        version: [8, 11, 17]
         include:
           - version: 11
             bazel: yes
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.version }}

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -40,6 +40,9 @@ Check the [Getting Started](getting-started.md) guide for a quick overview!
   - Duplicated keys in `properties` files
 - For Java 8, try to load properties files as `UTF-8` and fallback to `ISO-8859-1`. This is the
   default behavior in Java 9+
+- For Java < 17, try to load alternate properties files for obsolete languages: "iw", "in" and 
+  "ji" (replaced respectively by "he", "id" and "yi"). This is the default behavior starting with
+  Java 17
 - Simple caching. Easily integrates with other library like Guava cache.
 - Share arguments between subsequent calls to `L10nMessages#format()` calls
 - Graceful failure for invalid message formats and missing messages

--- a/docs/docs/resource-bundle.md
+++ b/docs/docs/resource-bundle.md
@@ -51,7 +51,6 @@ by keys. Use a comment before the key to provide translator instruction.
 ```properties
 # Translator instruction for message1
 key1=message1
-
 # Translator instruction for message2
 key2=message2
 ```
@@ -61,6 +60,27 @@ key2=message2
 With Java 8, the library uses a similar logic as what became standard with Java 9. It tries to load
 the `properties` as `UTF-8` and fallbacks to `ISO-8859-1` in case of errors. With Java 9+, the JDK
 code is directly used.
+
+## Legacy language codes
+
+Hebrew, Indonesian and Yiddish have obsolet forms: `iw`, `in` and `ji` which respectively
+map to the new language codes: `he`, `id` and `yi`.
+
+`L10nMessages` will load data from either forms and that regardless of the tag used when the locale
+is created.
+
+More concretely, `properties` files can be named
+`Message_iw.properties` or `Messages_he.properties`, and the locale created with either
+`new Locale("iw")` or `new Locale("he")`, `L10nMessages` will adapt accordingly.
+
+This is similar to the behavior introduced by Java 17, but addresses issues with previous versions
+of Java that will only load the data for the old forms.
+
+For more context, before Java 17, Locale's constructor always converted those three language codes
+to their earlier, obsoleted forms. The `properties` files had to be named using the obsolete forms,
+and that regardless of the form used when creating the locale. In Java 17, the new forms are used by
+default. The `properties` files can use either form. If the default form is missing it will attempt
+to load the alternate form.
 
 ## Other ResourceBundle types
 

--- a/integration-tests/test-performance/src/main/java/com/pinterest/l10nmessages/tests/BenchmarkRunner.java
+++ b/integration-tests/test-performance/src/main/java/com/pinterest/l10nmessages/tests/BenchmarkRunner.java
@@ -33,7 +33,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
-import org.openjdk.jmh.runner.options.WarmupMode;
 
 @L10nProperties(
     baseName = "com.pinterest.l10nmessages.tests.perf.Strings",

--- a/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatable/TestMessages.java
+++ b/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatable/TestMessages.java
@@ -19,5 +19,4 @@ public enum TestMessages {
   public String toString() {
     return key;
   }
-
 }

--- a/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatable/TestMessages2.java
+++ b/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatable/TestMessages2.java
@@ -19,5 +19,4 @@ public enum TestMessages2 {
   public String toString() {
     return key;
   }
-
 }

--- a/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatableJava9/TestMessages.java
+++ b/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatableJava9/TestMessages.java
@@ -19,5 +19,4 @@ public enum TestMessages {
   public String toString() {
     return key;
   }
-
 }

--- a/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatableJava9/TestMessages2.java
+++ b/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/repeatableJava9/TestMessages2.java
@@ -19,5 +19,4 @@ public enum TestMessages2 {
   public String toString() {
     return key;
   }
-
 }

--- a/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/valid/TestMessages.java
+++ b/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/valid/TestMessages.java
@@ -19,5 +19,4 @@ public enum TestMessages {
   public String toString() {
     return key;
   }
-
 }

--- a/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/validJava9/TestMessages.java
+++ b/l10nmessages-proc/src/test/resources/com/pinterest/l10nmessages/L10nPropertiesProcessorTest_IO/validJava9/TestMessages.java
@@ -19,5 +19,4 @@ public enum TestMessages {
   public String toString() {
     return key;
   }
-
 }

--- a/l10nmessages/src/main/java/com/pinterest/l10nmessages/AlternateLanguageCodes.java
+++ b/l10nmessages/src/main/java/com/pinterest/l10nmessages/AlternateLanguageCodes.java
@@ -1,0 +1,48 @@
+package com.pinterest.l10nmessages;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+class AlternateLanguageCodes {
+
+  private AlternateLanguageCodes() {
+    throw new AssertionError();
+  }
+
+  static Map<String, String> ALTERNATE_LANGUAGE_CODES = getAlternateLanguageCodes();
+
+  static Map<String, String> getAlternateLanguageCodes() {
+    Map<String, String> alternateLanguages = new LinkedHashMap<>();
+    alternateLanguages.put("iw", "he");
+    alternateLanguages.put("he", "iw");
+    alternateLanguages.put("in", "id");
+    alternateLanguages.put("id", "in");
+    alternateLanguages.put("ji", "yi");
+    alternateLanguages.put("yi", "ji");
+    return alternateLanguages;
+  }
+
+  public static boolean hasAlternateLanguageCode(Locale locale) {
+    return ALTERNATE_LANGUAGE_CODES.keySet().contains(locale.getLanguage());
+  }
+
+  public static String getAlternateResourceName(Locale locale, String resourceName) {
+    return getAlternateResourceName(locale.getLanguage(), resourceName);
+  }
+
+  static String getAlternateResourceName(String language, String resourceName) {
+    if (ALTERNATE_LANGUAGE_CODES.containsKey(language)) {
+      String alternateLanguage = ALTERNATE_LANGUAGE_CODES.get(language);
+      int idx = resourceName.lastIndexOf("_" + language);
+      if (idx != -1) {
+        resourceName =
+            resourceName.substring(0, idx)
+                + "_"
+                + alternateLanguage
+                + resourceName.substring(idx + 3);
+      }
+    }
+    return resourceName;
+  }
+}

--- a/l10nmessages/src/main/java/com/pinterest/l10nmessages/CharsetDecoderResourceBundleControl.java
+++ b/l10nmessages/src/main/java/com/pinterest/l10nmessages/CharsetDecoderResourceBundleControl.java
@@ -23,16 +23,29 @@ class CharsetDecoderResourceBundleControl extends ResourceBundle.Control {
   @Override
   public ResourceBundle newBundle(
       String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
-      throws IOException {
-
-    if (!"java.properties".equals(format)) {
-      throw new RuntimeException("Only support java.properties format");
-    }
+      throws IllegalAccessException, InstantiationException, IOException {
 
     ResourceBundle bundle = null;
-    String bundleName = toBundleName(baseName, locale);
-    String resourceName = toResourceName(bundleName, "properties");
 
+    if ("java.properties".equals(format)) {
+
+      String bundleName = toBundleName(baseName, locale);
+      String resourceName = toResourceName(bundleName, "properties");
+
+      try (InputStream stream = loader.getResourceAsStream(resourceName)) {
+        if (stream != null) {
+          bundle = new PropertyResourceBundle(new InputStreamReader(stream, charsetDecoder));
+        }
+      }
+    } else {
+      bundle = super.newBundle(baseName, locale, format, loader, reload);
+    }
+
+    return bundle;
+  }
+
+  private ResourceBundle getResourceBundle(
+      ClassLoader loader, ResourceBundle bundle, String resourceName) throws IOException {
     try (InputStream stream = loader.getResourceAsStream(resourceName)) {
       if (stream != null) {
         bundle = new PropertyResourceBundle(new InputStreamReader(stream, charsetDecoder));

--- a/l10nmessages/src/main/java/com/pinterest/l10nmessages/CharsetDecoderResourceBundleControl.java
+++ b/l10nmessages/src/main/java/com/pinterest/l10nmessages/CharsetDecoderResourceBundleControl.java
@@ -1,5 +1,8 @@
 package com.pinterest.l10nmessages;
 
+import static com.pinterest.l10nmessages.AlternateLanguageCodes.getAlternateResourceName;
+import static com.pinterest.l10nmessages.AlternateLanguageCodes.hasAlternateLanguageCode;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,11 +34,11 @@ class CharsetDecoderResourceBundleControl extends ResourceBundle.Control {
 
       String bundleName = toBundleName(baseName, locale);
       String resourceName = toResourceName(bundleName, "properties");
+      bundle = getResourceBundle(loader, resourceName);
 
-      try (InputStream stream = loader.getResourceAsStream(resourceName)) {
-        if (stream != null) {
-          bundle = new PropertyResourceBundle(new InputStreamReader(stream, charsetDecoder));
-        }
+      if (bundle == null && hasAlternateLanguageCode(locale)) {
+        resourceName = getAlternateResourceName(locale, resourceName);
+        bundle = getResourceBundle(loader, resourceName);
       }
     } else {
       bundle = super.newBundle(baseName, locale, format, loader, reload);
@@ -44,8 +47,9 @@ class CharsetDecoderResourceBundleControl extends ResourceBundle.Control {
     return bundle;
   }
 
-  private ResourceBundle getResourceBundle(
-      ClassLoader loader, ResourceBundle bundle, String resourceName) throws IOException {
+  private ResourceBundle getResourceBundle(ClassLoader loader, String resourceName)
+      throws IOException {
+    ResourceBundle bundle = null;
     try (InputStream stream = loader.getResourceAsStream(resourceName)) {
       if (stream != null) {
         bundle = new PropertyResourceBundle(new InputStreamReader(stream, charsetDecoder));

--- a/l10nmessages/src/main/java/com/pinterest/l10nmessages/JavaVersions.java
+++ b/l10nmessages/src/main/java/com/pinterest/l10nmessages/JavaVersions.java
@@ -1,0 +1,26 @@
+package com.pinterest.l10nmessages;
+
+final class JavaVersions {
+
+  static final int SPECIFIC_VERSION_AS_INT = specificationVersionAsInt();
+
+  private JavaVersions() {
+    throw new AssertionError();
+  }
+
+  static boolean isJava17AndUp() {
+    return SPECIFIC_VERSION_AS_INT >= 17;
+  }
+
+  static boolean isJava8() {
+    return SPECIFIC_VERSION_AS_INT == 8;
+  }
+
+  static int specificationVersionAsInt() {
+    String property = System.getProperty("java.specification.version");
+    if (property.startsWith("1.")) {
+      property = property.substring(2);
+    }
+    return Integer.parseInt(property);
+  }
+}

--- a/l10nmessages/src/main/java/com/pinterest/l10nmessages/ResourceBundleProviders.java
+++ b/l10nmessages/src/main/java/com/pinterest/l10nmessages/ResourceBundleProviders.java
@@ -27,22 +27,18 @@ public enum ResourceBundleProviders implements ResourceBundleProvider {
     public ResourceBundle get(String baseName, Locale locale) {
       ResourceBundle resourceBundle;
 
-      if (isJava8()) {
+      if (JavaVersions.isJava17AndUp()) {
+        resourceBundle = ResourceBundle.getBundle(baseName, locale);
+      } else {
         resourceBundle =
             ResourceBundle.getBundle(
                 baseName,
                 locale,
                 new CharsetDecoderResourceBundleControl(
                     new UTF8FallbackISO88591Charset().newDecoder()));
-      } else {
-        resourceBundle = ResourceBundle.getBundle(baseName, locale);
       }
 
       return resourceBundle;
     }
   };
-
-  static boolean isJava8() {
-    return "1.8".equals(System.getProperty("java.specification.version"));
-  }
 }

--- a/l10nmessages/src/test/java/com/pinterest/l10nmessages/AlternateLanguageCodesTest.java
+++ b/l10nmessages/src/test/java/com/pinterest/l10nmessages/AlternateLanguageCodesTest.java
@@ -1,0 +1,80 @@
+package com.pinterest.l10nmessages;
+
+import static com.pinterest.l10nmessages.JavaVersions.isJava17AndUp;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class AlternateLanguageCodesTest {
+
+  @Test
+  void alternateForHebrew_iw() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("iw", "Messages_iw.properties"))
+        .isEqualTo("Messages_he.properties");
+  }
+
+  @Test
+  void alternateForHebrew_he() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("he", "Messages_he.properties"))
+        .isEqualTo("Messages_iw.properties");
+  }
+
+  @Test
+  void alternateForHebrew_iw_IL() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("iw", "Messages_iw_IL.properties"))
+        .isEqualTo("Messages_he_IL.properties");
+  }
+
+  @Test
+  void alternateForHebrew_in() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("in", "Messages_in.properties"))
+        .isEqualTo("Messages_id.properties");
+  }
+
+  @Test
+  void alternateForHebrew_id() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("id", "Messages_id.properties"))
+        .isEqualTo("Messages_in.properties");
+  }
+
+  @Test
+  void alternateForHebrew_ji() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("ji", "Messages_ji.properties"))
+        .isEqualTo("Messages_yi.properties");
+  }
+
+  @Test
+  void alternateForHebrew_yi() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("yi", "Messages_yi.properties"))
+        .isEqualTo("Messages_ji.properties");
+  }
+
+  @Test
+  void basedOnJavaVersion() {
+    if (isJava17AndUp()) {
+      System.out.println(new Locale("he"));
+      assertThat(
+              AlternateLanguageCodes.getAlternateResourceName(
+                  new Locale("he"), "Messages_he.properties"))
+          .isEqualTo("Messages_iw.properties");
+    } else {
+      assertThat(
+              AlternateLanguageCodes.getAlternateResourceName(
+                  new Locale("iw"), "Messages_iw.properties"))
+          .isEqualTo("Messages_he.properties");
+    }
+  }
+
+  @Test
+  void doNothingForRoot() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("iw", "Messages.properties"))
+        .isEqualTo("Messages.properties");
+  }
+
+  @Test
+  void doNothingForOtherLocale() {
+    assertThat(AlternateLanguageCodes.getAlternateResourceName("iw", "Messages_fr.properties"))
+        .isEqualTo("Messages_fr.properties");
+  }
+}

--- a/l10nmessages/src/test/java/com/pinterest/l10nmessages/JavaVersionsTest.java
+++ b/l10nmessages/src/test/java/com/pinterest/l10nmessages/JavaVersionsTest.java
@@ -1,0 +1,13 @@
+package com.pinterest.l10nmessages;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JavaVersionsTest {
+
+  @Test
+  void version() {
+    int versionAsInt = JavaVersions.specificationVersionAsInt();
+    Assertions.assertThat(versionAsInt).isGreaterThanOrEqualTo(8);
+  }
+}

--- a/l10nmessages/src/test/java/com/pinterest/l10nmessages/ResourceBundleProvidersTest.java
+++ b/l10nmessages/src/test/java/com/pinterest/l10nmessages/ResourceBundleProvidersTest.java
@@ -1,8 +1,10 @@
 package com.pinterest.l10nmessages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Locale;
+import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,5 +75,15 @@ class ResourceBundleProvidersTest {
     ResourceBundle resourceBundle =
         ResourceBundle.getBundle("com.pinterest.l10nmessages.MessagesISO", Locale.ROOT);
     assertThat(resourceBundle.getString("iso")).isEqualTo("break because of accented character: à");
+  }
+
+  @Test
+  public void missingBundle() {
+    assertThatThrownBy(
+            () ->
+                ResourceBundleProviders.DEFAULT_OR_BACKPORT.get(
+                    "a.missing.bundle.Messages", Locale.FRENCH))
+        .isInstanceOf(MissingResourceException.class)
+        .hasMessageContaining("Can't find bundle for base name a.missing.bundle.Messages");
   }
 }

--- a/l10nmessages/src/test/resources/com/pinterest/l10nmessages/MessagesHE_he.properties
+++ b/l10nmessages/src/test/resources/com/pinterest/l10nmessages/MessagesHE_he.properties
@@ -1,0 +1,1 @@
+welcome=Welcome! - he

--- a/l10nmessages/src/test/resources/com/pinterest/l10nmessages/MessagesIW_iw.properties
+++ b/l10nmessages/src/test/resources/com/pinterest/l10nmessages/MessagesIW_iw.properties
@@ -1,0 +1,1 @@
+welcome=Welcome! - iw

--- a/l10nmessages/src/test/resources/com/pinterest/l10nmessages/Messages_he.properties
+++ b/l10nmessages/src/test/resources/com/pinterest/l10nmessages/Messages_he.properties
@@ -1,0 +1,1 @@
+welcome=Welcome! - he

--- a/l10nmessages/src/test/resources/com/pinterest/l10nmessages/Messages_iw.properties
+++ b/l10nmessages/src/test/resources/com/pinterest/l10nmessages/Messages_iw.properties
@@ -1,0 +1,1 @@
+welcome=Welcome! - iw


### PR DESCRIPTION
To start running the test on Java 17